### PR TITLE
Fixed ToolBarItem visibility for Android

### DIFF
--- a/MVP.Android/Resources/values/styles.xml
+++ b/MVP.Android/Resources/values/styles.xml
@@ -28,6 +28,12 @@
         <item name="windowActionModeOverlay">true</item>
         <item name="android:datePickerDialogTheme">@style/AppCompatDialogStyle</item>
         <item name="android:colorActivatedHighlight">@android:color/transparent</item>
+
+      <!-- Sets text color for ToolBarItems in Xamarin.Forms -->
+      <item name="android:actionMenuTextColor">@android:color/black</item>
+
+      <!-- Disable all-caps text for buttons and ToolBarItem text -->
+      <item name="android:textAllCaps">false</item>
     </style>
     <style name="AppCompatDialogStyle" parent="Theme.AppCompat.Light.Dialog">
         <item name="colorAccent">@color/colorPrimary</item>


### PR DESCRIPTION
The ToolBarItems such as "Sign in" and "Add/Edit" weren't displaying for Android. Had to set some Android styles to make them visible. Also suppressed the all-caps text preference Android sets on buttons to comply with the design (I can remove this if preferred).