### PR TITLE
Move RefreshView up in view hierarchy to avoid crashes on Android

### DIFF
--- a/MVP/Pages/ContributionsPage.xaml
+++ b/MVP/Pages/ContributionsPage.xaml
@@ -31,49 +31,49 @@
     <mvp:AppFrame ShowSecondaryButton="{Binding State, Converter={StaticResource NotLoadingConverter}}"
                   x:Name="appFrame">
         <mvp:AppFrame.Content>
-            <Grid xct:StateLayout.CurrentState="{Binding State}"
-                  xct:StateLayout.AnimateStateChanges="False"
-                  xct:StateLayout.CurrentCustomStateKey="{Binding CustomStateKey}">
-
-                <xct:StateLayout.StateViews>
-                    <xct:StateView StateKey="Loading"
-                                   RepeatCount="3"
-                                   Template="{StaticResource contribution_item_loading}" />
-
-                    <xct:StateView StateKey="Empty"
-                                   HorizontalOptions="FillAndExpand"
-                                   VerticalOptions="FillAndExpand" >
-                        <controls:EmptyState Title="{x:Static resources:Translations.empty_state_title}"
-                                             Description="{x:Static resources:Translations.empty_state_contributions}"
-                                             ImageSource="Resource://empty.svg"
-                                             CommandText="Retry"
-                                             Command="{Binding RefreshDataCommand}" />
-                    </xct:StateView>
-
-                    <xct:StateView StateKey="Error"
-                                   HorizontalOptions="FillAndExpand"
-                                   VerticalOptions="FillAndExpand" >
-                        <controls:EmptyState Title="{x:Static resources:Translations.error_title}"
-                                             Description="{x:Static resources:Translations.error_data_not_loaded}"
-                                             ImageSource="Resource://error.svg"
-                                             CommandText="Retry"
-                                             Command="{Binding RefreshDataCommand}" />
-                    </xct:StateView>
-
-                    <xct:StateView StateKey="Custom"
-                                   CustomStateKey="{x:Static mvp:StateKeys.Offline}"
-                                   HorizontalOptions="FillAndExpand"
-                                   VerticalOptions="FillAndExpand" >
-                        <controls:EmptyState Title="{x:Static resources:Translations.error_offline_title}"
-                                             Description="{x:Static resources:Translations.offline_contributions}"
-                                             ImageSource="Resource://empty.svg"
-                                             CommandText="Retry"
-                                             Command="{Binding RefreshDataCommand}" />
-                    </xct:StateView>
-                </xct:StateLayout.StateViews>
-
-                <RefreshView Command="{Binding RefreshDataCommand}"
+            <RefreshView Command="{Binding RefreshDataCommand}"
                              IsRefreshing="{Binding IsRefreshing, Mode=OneWay}">
+                <Grid xct:StateLayout.CurrentState="{Binding State}"
+                      xct:StateLayout.AnimateStateChanges="False"
+                      xct:StateLayout.CurrentCustomStateKey="{Binding CustomStateKey}">
+
+                    <xct:StateLayout.StateViews>
+                        <xct:StateView StateKey="Loading"
+                                       RepeatCount="3"
+                                       Template="{StaticResource contribution_item_loading}" />
+
+                        <xct:StateView StateKey="Empty"
+                                       HorizontalOptions="FillAndExpand"
+                                       VerticalOptions="FillAndExpand" >
+                            <controls:EmptyState Title="{x:Static resources:Translations.empty_state_title}"
+                                                 Description="{x:Static resources:Translations.empty_state_contributions}"
+                                                 ImageSource="Resource://empty.svg"
+                                                 CommandText="Retry"
+                                                 Command="{Binding RefreshDataCommand}" />
+                        </xct:StateView>
+
+                        <xct:StateView StateKey="Error"
+                                       HorizontalOptions="FillAndExpand"
+                                       VerticalOptions="FillAndExpand" >
+                            <controls:EmptyState Title="{x:Static resources:Translations.error_title}"
+                                                 Description="{x:Static resources:Translations.error_data_not_loaded}"
+                                                 ImageSource="Resource://error.svg"
+                                                 CommandText="Retry"
+                                                 Command="{Binding RefreshDataCommand}" />
+                        </xct:StateView>
+
+                        <xct:StateView StateKey="Custom"
+                                       CustomStateKey="{x:Static mvp:StateKeys.Offline}"
+                                       HorizontalOptions="FillAndExpand"
+                                       VerticalOptions="FillAndExpand" >
+                            <controls:EmptyState Title="{x:Static resources:Translations.error_offline_title}"
+                                                 Description="{x:Static resources:Translations.offline_contributions}"
+                                                 ImageSource="Resource://empty.svg"
+                                                 CommandText="Retry"
+                                                 Command="{Binding RefreshDataCommand}" />
+                        </xct:StateView>
+                    </xct:StateLayout.StateViews>
+
                     <CollectionView ItemsSource="{Binding Contributions}"
                                     ItemsUpdatingScrollMode="KeepScrollOffset"
                                     ItemTemplate="{StaticResource contribution_item}"
@@ -90,8 +90,8 @@
                                             BindableLayout.ItemsSource="{StaticResource faux_list}" />
                         </CollectionView.Footer>
                     </CollectionView>
-                </RefreshView>
-            </Grid>
+                </Grid>
+            </RefreshView>
         </mvp:AppFrame.Content>
     </mvp:AppFrame>
 </pages:BaseContentPage>


### PR DESCRIPTION
Fixes #123 (or atleast gives a clue what the issue is)

After some investigation, I found that the crash is caused by the 
```
<xct:StateView StateKey="Loading"
                                       RepeatCount="3"
                                       Template="{StaticResource contribution_item_loading}" />
```
beeing toggled during the refresh task. I dont know exactly why it causes a crash in the `RefreshView`, I suspect since it changes the view tree while the refresh view is active.

I found that simply moving the refresh view to be the parent of both the collection and stateview mitgates this issue (only tested on a hardware pixel 3a).

This will ofcouse stop the `StateView` from overlapping the `RefreshView`, I'm not sure if thats okay or destroys the desired UI. If not, I hope this atleast helps in identifing the underlying issue. 